### PR TITLE
Fix Header main row: Bottom border color can't be 100% solid

### DIFF
--- a/inc/modules/hf-builder/components/header/row/css.php
+++ b/inc/modules/hf-builder/components/header/row/css.php
@@ -71,7 +71,7 @@ foreach( $rows as $row ) {
         )
     );
     $css .= ".bhfb-$row { border-bottom-style: solid; }";
-    $css .= Botiga_Custom_CSS::get_border_bottom_color_rgba_css( "botiga_header_row__{$row}_border_bottom_color", '#EAEAEA', ".bhfb-$row", 0.1 );
+    $css .= Botiga_Custom_CSS::get_border_bottom_color_rgba_css( "botiga_header_row__{$row}_border_bottom_color", '#EAEAEA', ".bhfb-$row", 1 );
 
     // Padding
     $css .= Botiga_Custom_CSS::get_responsive_dimensions_css( 


### PR DESCRIPTION
Fix Header main row: Bottom border color can't be 100% solid
https://www.notion.so/athemes/Header-main-row-Bottom-border-color-can-t-be-100-solid-32ef11fd19ef4c98bc50b178199e62fa