### PR TITLE
Fix cart message contents alignment

### DIFF
--- a/assets/sass/plugins/woocommerce/_notices.scss
+++ b/assets/sass/plugins/woocommerce/_notices.scss
@@ -48,6 +48,15 @@
             margin-inline-end: 0;
 			margin-inline-start: 15px;
 		}
+
+		.woocommerce-message {
+			display: flex;
+			align-content: center;
+			flex-wrap: nowrap;
+			flex-direction: row;
+			align-items: center;
+			justify-content: space-between;
+		}
     }
 
     &.no-single-breadcrumbs {


### PR DESCRIPTION
Fix cart message contents alignment

https://www.notion.so/athemes/WooCommerce-Notices-View-Cart-button-wrong-aligned-1d7959f5c29a80ff8822c39f5537584e