### PR TITLE
wpfc.io deployments for Botiga

### DIFF
--- a/.github/workflows/auto-testing-builds.yml
+++ b/.github/workflows/auto-testing-builds.yml
@@ -8,6 +8,7 @@ on:
 # Defines the jobs that will be executed as part of this workflow.
 jobs:
   build:
+    name: Prepare and upload builds in team.wpforms.com/builds
     # Specifies the runner environment for the job. In this case, it\'s Ubuntu 22.04.
     runs-on: ubuntu-22.04
 
@@ -146,3 +147,34 @@ jobs:
         with:
           name: ${{ env.PROJECT_NAME }}.zip
           path: ${{ env.PROJECT_NAME }}.zip
+
+  wpfcio-deployments:
+    name: Deploy at wpfc.io sites
+    if: github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-22.04
+    needs: builds
+
+    steps:
+      -   name: Setup key
+          run: |
+            echo "${{ SECRETS.WPFORMS_TEST_DOCKER_SSH_PRIVATE_KEY }}" > /root/.ssh/id_ed25519
+            chmod 600 /root/.ssh/id_ed25519 && chmod 700 /root/.ssh
+
+      - name: Upload to x.athemes.wpfc.io
+        run: |
+          rsync --rsh="ssh -o StrictHostKeyChecking=no -p18765" \
+                --ignore-times \
+                --archive \
+                --verbose \
+                --compress \
+                --human-readable \
+                --progress \
+                --whole-file \
+                --remove-source-files \
+                builds/ \
+                qabotigaathemes@159.89.184.130:/sites/qa-botiga.athemes.wpfc.io/files/wp-content/plugins/
+
+      -   name: Install on x.athemes.wpfc.io
+          run: |
+              echo "Installing: ${{ env.PROJECT_NAME }}.zip"
+              ssh qabotigaathemes@159.89.184.130 "cd /sites/qa-botiga.athemes.wpfc.io/files/wp-content/themes && rm -rf ${{ env.PROJECT_NAME }} && unzip ${{ env.PROJECT_NAME }}.zip && rm ${{ env.PROJECT_NAME }}.zip" < /dev/null


### PR DESCRIPTION
## Description
Should automatically deploy the latest `development` branch version of the theme to qa-botiga.athemes.wpfc.io


## Motivation and Context
To automate testing. See #394 (no changelog needed)

## QA Review
<!---
Please describe in detail how you tested your changes.
Include details of your testing environment and the tests you ran to
see how your change affects other areas of the code, etc.
-->
1. Merge a feature to `develop`
2. Make sure it shows up at qa-botiga.athemes.wpfc.io

3. Profit!

## Self-Testing Checklist
<!---
The PR author fills in this section.
If the checkbox is not relevant - still mark it as checked.
-->
- [ ] I tested both **Free** and **paid** version of the plugin.
- [ ] I tested these changes to the best of my abilities with browser console opened and debug.log monitored.
- [ ] I checked situations when users **update free/pro in a different order**.
- [ ] **Backward compatibility** with users updating from an older version to the one with these changes has been checked.
- [ ] For the Block Editor related changes, I checked in both Sydney and Botiga theme.
- [ ] For the front-end related changes, I checked in both Sydney and Botiga theme.
- [ ] I tested in different browsers (Chrome/Firefox/Safari/Edge).
- [ ] I tested on Multisite OR this change does not affect Multisite in any way.
- [ ] I tested with LTR and RTL languages.
<!--
If you have checked any of the above cases, please add some context about the reason, which editor/browser/functionality should be tested in particular, etc.
-->