### PR TITLE
Fix broken parts in Botiga in wordpress.org preview

### DIFF
--- a/assets/js/src/custom.js
+++ b/assets/js/src/custom.js
@@ -1813,16 +1813,16 @@ botiga.misc = {
 		}
 	},
 	customizer: function() {
-		if( ! window.parent.document.body.classList.contains( 'wp-customizer' ) ) {
+		if ( typeof wp === 'undefined' || typeof wp.customize === 'undefined' ) {
 			return false;
 		}
 
-		window.onload = function() {
+		wp.customize.bind( 'preview-ready', function() {
 			var cart_count = document.querySelectorAll( '.cart-count' );
 			if( cart_count.length ) {
 				jQuery( document.body ).trigger( 'wc_fragment_refresh' );
 			}
-		}
+		} );
 	}
 }
 

--- a/assets/sass/abstracts/variables/_colors.scss
+++ b/assets/sass/abstracts/variables/_colors.scss
@@ -20,5 +20,6 @@ $color__border-input: #ccc;
 $color__border-abbr: #666;
 
 $color__primary: #212121;
+$color__white: #ffffff;
 $color__grey: #666666;
 $color__hover: #757575;

--- a/assets/sass/base/elements/_body.scss
+++ b/assets/sass/base/elements/_body.scss
@@ -35,7 +35,7 @@ body {
 
 		svg {
 			&:not(.stroke-based) {
-				fill: $color__white;
+				fill: $color__white; // change the default color to white
 			}
 		}
 	}	

--- a/assets/sass/base/elements/_body.scss
+++ b/assets/sass/base/elements/_body.scss
@@ -32,5 +32,11 @@ body {
 	.ws-svg-icon {
 		width: 24px;
 		height: 24px;
+
+		svg {
+			&:not(.stroke-based) {
+				fill: $color__white;
+			}
+		}
 	}	
 }

--- a/assets/sass/components/navigation/_navigation.scss
+++ b/assets/sass/components/navigation/_navigation.scss
@@ -20,8 +20,8 @@
 					display: flex;
 					flex-wrap: wrap;
 	
-					li + li {
-						//margin-left: 35px;
+					> li + li {
+						margin-left: 35px;
 					}
 				}
 			}

--- a/assets/sass/components/navigation/_navigation.scss
+++ b/assets/sass/components/navigation/_navigation.scss
@@ -5,8 +5,7 @@
 	width: 100%;
 
 	&.main-navigation {
-		> div#primary-menu,
-		> div {
+		> div#primary-menu {
 			> ul {
 				list-style: none;
 				padding: 0;
@@ -16,14 +15,13 @@
 
 	@media(min-width: 1025px) {
 		&.main-navigation {
-			> div#primary-menu,
-			> div {
+			> div#primary-menu {
 				> ul {
 					display: flex;
 					flex-wrap: wrap;
 	
 					li + li {
-						margin-left: 35px;
+						//margin-left: 35px;
 					}
 				}
 			}

--- a/assets/sass/components/navigation/_navigation.scss
+++ b/assets/sass/components/navigation/_navigation.scss
@@ -5,7 +5,8 @@
 	width: 100%;
 
 	&.main-navigation {
-		> div#primary-menu {
+		> div#primary-menu,
+		> div {
 			> ul {
 				list-style: none;
 				padding: 0;
@@ -15,7 +16,8 @@
 
 	@media(min-width: 1025px) {
 		&.main-navigation {
-			> div#primary-menu {
+			> div#primary-menu,
+			> div {
 				> ul {
 					display: flex;
 					flex-wrap: wrap;
@@ -28,12 +30,15 @@
 		}
 	}
 
-	.botiga-dropdown-ul {
+	.botiga-dropdown-ul,
+	.nav-menu {
 		list-style: none;
 		margin: 0;
 		padding-left: 0;
 
-		.botiga-dropdown-ul {
+		.botiga-dropdown-ul,
+		.children,
+		.sub-menu {
 			width: 200px;
 			box-shadow: 0 0 15px rgba(0,0,0,.1);
 			float: left;
@@ -47,12 +52,16 @@
 			transform: translate3d(0, 15px, 0);
 			transition: ease transform 300ms, ease opacity 300ms;
 
-			.botiga-dropdown-ul {
+			.botiga-dropdown-ul,
+			.children,
+			.sub-menu {
 				left: 100%;
 				top: 0;
 			}
 
-			.botiga-dropdown-li {
+			.botiga-dropdown-li,
+			.page_item,
+			.menu-item {
 				background: #fff;
 				padding: 0;
 				display: flex;
@@ -60,7 +69,13 @@
 
 				&.hovered > .botiga-dropdown-ul,
 				&:hover > .botiga-dropdown-ul,
-				&.focus > .botiga-dropdown-ul {
+				&.focus > .botiga-dropdown-ul,
+				&.hovered > .children,
+				&:hover > .children,
+				&.focus > .children,
+				&.hovered > .sub-menu,
+				&:hover > .sub-menu,
+				&.focus > .sub-menu {
 					display: block;
 					left: 100%;
 				}
@@ -81,7 +96,9 @@
 				}
 			}
 
-			.botiga-dropdown-link {
+			.botiga-dropdown-link,
+			.page_item a,
+			.menu-item a {
 				width: 100%;
 				display: inline-block;
 				text-transform: none;
@@ -91,7 +108,13 @@
 
 		.botiga-dropdown-li.hovered > .botiga-dropdown-ul,
 		.botiga-dropdown-li:hover > .botiga-dropdown-ul,
-		.botiga-dropdown-li.focus > .botiga-dropdown-ul {
+		.botiga-dropdown-li.focus > .botiga-dropdown-ul,
+		.page_item.hovered > .children,
+		.page_item:hover > .children,
+		.page_item.focus > .children,
+		.menu-item.hovered > .sub-menu,
+		.menu-item:hover > .sub-menu,
+		.menu-item.focus > .sub-menu {
 			left: auto;
 			top: 100%;
 			opacity: 1;
@@ -109,7 +132,9 @@
 				bottom: 100%;
 			}
 
-			.botiga-dropdown-ul {
+			.botiga-dropdown-ul,
+			.children,
+			.sub-menu {
 				top: 0;
 
 				&.sub-menu-reverse {
@@ -125,7 +150,9 @@
 		}
 	}
 
-	.botiga-dropdown-li {
+	.botiga-dropdown-li,
+	.page_item,
+	.menu-item {
 		position: relative;
 		margin-right: 35px;
 		padding-bottom: 0;
@@ -135,7 +162,9 @@
 		}
 	}
 
-	.botiga-dropdown-link {
+	.botiga-dropdown-link,
+	.page_item a,
+	.menu-item a {
 		padding: 10px 0;
 		display: inline-block;
 		text-decoration: none;
@@ -152,14 +181,24 @@
 	}
 
 	&.with-hover-delay {
-		.botiga-dropdown-ul {
-			.botiga-dropdown-ul {
+		.botiga-dropdown-ul,
+		.children,
+		.sub-menu {
+			.botiga-dropdown-ul,
+			.children,
+			.sub-menu {
 				transition-delay: 0ms;
 			}
 
 			.botiga-dropdown-li.hovered > .botiga-dropdown-ul,
 			.botiga-dropdown-li:hover > .botiga-dropdown-ul,
-			.botiga-dropdown-li.focus > .botiga-dropdown-ul {
+			.botiga-dropdown-li.focus > .botiga-dropdown-ul,
+			.page_item.hovered > .children,
+			.page_item:hover > .children,
+			.page_item.focus > .children,
+			.menu-item.hovered > .sub-menu,
+			.menu-item:hover > .sub-menu,
+			.menu-item.focus > .sub-menu {
 				transition-delay: 300ms;
 			}
 		}
@@ -169,17 +208,22 @@
 	@media(max-width: 1024px) {
 
 		&.botiga-dropdown-mobile-accordion {
-			.botiga-dropdown-li {
+			.botiga-dropdown-li,
+			.page_item,
+			.menu-item {
 				margin-right: 0;
 
-				&.menu-item-has-children {
+				&.menu-item-has-children,
+				&.page_item_has_children {
 					display: flex;
 					flex-wrap: wrap;
-					> .botiga-dropdown-link {
+					> .botiga-dropdown-link,
+					> a {
 						width: calc( 100% - ( var(--dropdown--symbol--size) + 0.5em ) );
 					}
 
-					> .sub-menu {
+					> .sub-menu,
+					> .children {
 						position: relative;
 						width: 100%;
 						left: 0;
@@ -188,17 +232,21 @@
 						transform: none;
 						box-shadow: none;
 
-						> .botiga-dropdown-li {
+						> .botiga-dropdown-li,
+						> .page_item,
+						> .menu-item {
 							background-color: transparent;
 						}
 
-						.sub-menu {
+						.sub-menu,
+						.children {
 							padding-left: 20px;
 						}
 					}
 
 					&.expand {
-						> .sub-menu {
+						> .sub-menu,
+						> .children {
 							opacity: 1;
 							height: auto;
 							overflow: visible;
@@ -206,7 +254,8 @@
 					}
 
 					&:not(.expand) {
-						> .sub-menu {
+						> .sub-menu,
+						> .children {
 							opacity: 0;
 							height: 0;
 							overflow: hidden;
@@ -243,12 +292,14 @@
 }
 
 /* Small menu. */
-.botiga-dropdown.toggled .botiga-dropdown-ul {
+.botiga-dropdown.toggled .botiga-dropdown-ul,
+.botiga-dropdown.toggled .nav-menu {
 	display: block;
 }
 
 @media screen and (min-width: 1025px) {
-	.botiga-dropdown .botiga-dropdown-ul {
+	.botiga-dropdown .botiga-dropdown-ul,
+	.botiga-dropdown .nav-menu {
 		display: flex;
 		flex-wrap: wrap;
 	}


### PR DESCRIPTION
This PR contains the following:
- Fix CORS issue appears in browser console when previewing Botiga theme on wordpress.org
- Add default color "white" to the search submit button.
- Add support for WordPress navigation fallback structure.

Steps to test:
- CORS error: Should be gone after releasing Botiga when previewing the theme on wordpress.org
- The search icon: The root cause of the search icon doesn't appear is because themes on wordpress.org on preview cannot generate style files. So instead, we should supply a default value. Should be tested after release.
- The WordPress navigation menu: On wordpress.org, the system acts different, and it goes with their fallbacks instead if the theme's fallback. The nav menu now should be tested on wordpress.org after release, however it should be tested also before release for any potential issues or broken styles + test the mega menu too.

See #381 